### PR TITLE
Add a simple numpy datetime64 compatibility shim

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,11 +53,15 @@ requirements = [
     'pynacl>=1.4.0',
     'pyyaml>=5.4.1',
     'txaio>=21.2.1',
+]
+
+numpy_requirements = [
     'numpy>=1.20.1',
 ]
 
 extras_require = {
-    'dev': []
+    'dev': [],
+    'numpy': numpy_requirements,
 }
 
 with open('requirements-dev.txt') as f:

--- a/zlmdb/_types.py
+++ b/zlmdb/_types.py
@@ -36,12 +36,8 @@ import cbor2
 import flatbuffers
 from txaio import time_ns
 
-try:
-    import numpy as np
-except ImportError:
-    HAS_NUMPY = False
-else:
-    HAS_NUMPY = True
+from flatbuffers.compat import import_numpy
+np = import_numpy()
 
 CHARSET = u'345679ACEFGHJKLMNPQRSTUVWXY'
 """

--- a/zlmdb/tests/_schema_mnode_log.py
+++ b/zlmdb/tests/_schema_mnode_log.py
@@ -27,14 +27,15 @@
 import pprint
 import uuid
 
-import numpy as np
-
 import flatbuffers
 
 from zlmdb import table, MapTimestampUuidFlatBuffers
 from txaio import time_ns
 
 import MNodeLog as MNodeLogGen
+
+from flatbuffers.compat import import_numpy
+np = import_numpy()
 
 
 class _MNodeLogGen(MNodeLogGen.MNodeLog):

--- a/zlmdb/tests/test_select.py
+++ b/zlmdb/tests/test_select.py
@@ -27,17 +27,19 @@
 import os
 import uuid
 import random
+import pytest
 import struct
+import txaio
 
 import flatbuffers
-import numpy as np
-import pytest
+from flatbuffers.compat import import_numpy
 
 import zlmdb  # noqa
 
 from _schema_mnode_log import Schema, MNodeLog
 
-import txaio
+np = import_numpy()
+
 txaio.use_twisted()
 
 from txaio import time_ns  # noqa


### PR DESCRIPTION
I think numpy(which is a huge library) is a bit overkill for what seems to be a small subset of `datetime64` functionality, we can just add a small shim class for the parts we need(seems to mostly just be nanosecond precision `datetime64` object serialization/deserialization functionality).