### PR TITLE
Use datetime64 ctypes wrapper instead of numpy datetime64

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,11 +53,15 @@ requirements = [
     'pynacl>=1.4.0',
     'pyyaml>=5.4.1',
     'txaio>=21.2.1',
+]
+
+numpy_requirements = [
     'numpy>=1.20.1',
 ]
 
 extras_require = {
-    'dev': []
+    'dev': [],
+    'numpy': numpy_requirements,
 }
 
 with open('requirements-dev.txt') as f:

--- a/zlmdb/__init__.py
+++ b/zlmdb/__init__.py
@@ -121,6 +121,7 @@ from ._pmap import PersistentMap, \
 from ._transaction import Transaction, TransactionStats, walltime
 from ._database import Database
 from ._schema import Schema
+from ._types import datetime64
 
 __all__ = (
     '__version__',
@@ -131,6 +132,7 @@ __all__ = (
     'walltime',
     'MapSlotUuidUuid',
     'table',
+    'datetime64',
 
     #
     # Errors

--- a/zlmdb/tests/_schema_mnode_log.py
+++ b/zlmdb/tests/_schema_mnode_log.py
@@ -27,11 +27,9 @@
 import pprint
 import uuid
 
-import numpy as np
-
 import flatbuffers
 
-from zlmdb import table, MapTimestampUuidFlatBuffers
+from zlmdb import table, MapTimestampUuidFlatBuffers, datetime64
 from txaio import time_ns
 
 import MNodeLog as MNodeLogGen
@@ -164,13 +162,13 @@ class MNodeLog(object):
         assert 'timestamp' in heartbeat and type(heartbeat['timestamp']) == int
 
         obj = MNodeLog()
-        obj._timestamp = np.datetime64(time_ns(), 'ns')
+        obj._timestamp = datetime64(time_ns())
         obj._node_id = node_id
         obj._run_id = uuid.UUID(bytes=b'\0' * 16)
         obj._state = heartbeat.get('state', None)
-        obj._ended = np.datetime64(heartbeat['ended'], 'ns') if heartbeat.get('ended', None) else None
+        obj._ended = datetime64(heartbeat['ended']) if heartbeat.get('ended', None) else None
         obj._session = heartbeat.get('session', None)
-        obj._sent = np.datetime64(heartbeat['timestamp'], 'ns') if heartbeat.get('timestamp', None) else None
+        obj._sent = datetime64(heartbeat['timestamp']) if heartbeat.get('timestamp', None) else None
         obj._seq = heartbeat.get('seq', None)
 
         workers = heartbeat.get('workers', {})
@@ -320,12 +318,12 @@ class MNodeLog(object):
     @property
     def timestamp(self):
         if self._timestamp is None and self._from_fbs:
-            self._timestamp = np.datetime64(self._from_fbs.Timestamp(), 'ns')
+            self._timestamp = datetime64(self._from_fbs.Timestamp())
         return self._timestamp
 
     @timestamp.setter
     def timestamp(self, value):
-        assert value is None or isinstance(value, np.datetime64)
+        assert value is None or isinstance(value, datetime64)
         self._timestamp = value
 
     @property
@@ -368,12 +366,12 @@ class MNodeLog(object):
     @property
     def ended(self):
         if self._ended is None and self._from_fbs:
-            self._ended = np.datetime64(self._from_fbs.Ended(), 'ns')
+            self._ended = datetime64(self._from_fbs.Ended())
         return self._ended
 
     @ended.setter
     def ended(self, value):
-        assert value is None or isinstance(value, np.datetime64)
+        assert value is None or isinstance(value, datetime64)
         self._ended = value
 
     @property
@@ -390,12 +388,12 @@ class MNodeLog(object):
     @property
     def sent(self):
         if self._sent is None and self._from_fbs:
-            self._sent = np.datetime64(self._from_fbs.Sent(), 'ns')
+            self._sent = datetime64(self._from_fbs.Sent())
         return self._sent
 
     @sent.setter
     def sent(self, value):
-        assert value is None or isinstance(value, np.datetime64)
+        assert value is None or isinstance(value, datetime64)
         self._sent = value
 
     @property

--- a/zlmdb/tests/test_select.py
+++ b/zlmdb/tests/test_select.py
@@ -30,7 +30,6 @@ import random
 import struct
 
 import flatbuffers
-import numpy as np
 import pytest
 
 import zlmdb  # noqa
@@ -38,6 +37,9 @@ import zlmdb  # noqa
 from _schema_mnode_log import Schema, MNodeLog
 
 import txaio
+
+from zlmdb import datetime64
+
 txaio.use_twisted()
 
 from txaio import time_ns  # noqa
@@ -65,11 +67,11 @@ def rfloat():
 
 def fill_mnodelog(obj):
 
-    obj.timestamp = np.datetime64(time_ns(), 'ns') + np.timedelta64(random.randint(1, 120), 's')
+    obj.timestamp = datetime64(time_ns() + (random.randint(1, 120) * 1000000000))
     obj.node_id = uuid.uuid4()
     obj.run_id = uuid.uuid4()
     obj.state = random.randint(1, 2)
-    obj.ended = obj.timestamp + np.timedelta64(random.randint(1, 120), 's')
+    obj.ended = datetime64(int(obj.timestamp) + (random.randint(1, 120) * 1000000000))
     obj.session = random.randint(1, 9007199254740992)
     obj.sent = obj.timestamp
     obj.seq = random.randint(1, 10000)
@@ -347,8 +349,8 @@ def test_mnodelog_queries(N=1000):
                     mnodelog = schema.mnode_logs[txn, key]
                     assert mnodelog
 
-                first_key = (np.datetime64(0, 'ns'), uuid.UUID(bytes=b'\0' * 16))
-                last_key = (np.datetime64(2**63 - 1, 'ns'), uuid.UUID(bytes=b'\xff' * 16))
+                first_key = (datetime64(0), uuid.UUID(bytes=b'\0' * 16))
+                last_key = (datetime64(2**63 - 1), uuid.UUID(bytes=b'\xff' * 16))
                 cnt = schema.mnode_logs.count_range(txn, from_key=first_key, to_key=last_key)
                 assert cnt == N
 


### PR DESCRIPTION
Seems to perform a good bit better, especially when running on pypy.

Before:
```python
zlmdb/tests/test_select.py::test_mnodelog_bigtable_size160k 
Inserted 160000 records in 49 seconds [3263 records/sec]
Selected 8000000 records in 44 seconds [180357 records/sec]
Performed 160000 range counts in 15 seconds [10680 queries/sec]
```

After:
```python
Inserted 160000 records in 39 seconds [4072 records/sec]
Selected 8000000 records in 21 seconds [379112 records/sec]
Performed 160000 range counts in 14 seconds [11674 queries/sec]
```