### PR TITLE
Make sure PyYAML 6 can be used

### DIFF
--- a/zlmdb/_database.py
+++ b/zlmdb/_database.py
@@ -236,7 +236,7 @@ class Schema(object):
     @staticmethod
     def parse(filename, klassmap=KV_TYPE_TO_CLASS):
         with open(filename) as f:
-            _meta = yaml.load(f.read())
+            _meta = yaml.safe_load(f.read())
 
             meta = {}
             slots = {}


### PR DESCRIPTION
PyYAML 6.0's changelog says:
"always require Loader arg to `yaml.load()"

Use the safe_load() function instead.

Link: https://github.com/yaml/pyyaml/releases/tag/6.0