### PR TITLE
Use existing flatc with ZLMDB_FLATC_EXECUTABLE env variable

### DIFF
--- a/.audit/jameshilliard_flatc_override.md
+++ b/.audit/jameshilliard_flatc_override.md
@@ -1,0 +1,7 @@
+- [x] I did **not** use any AI-assistance tools to help create this pull request.
+- [ ] I **did** use AI-assistance tools to *help* create this pull request.
+- [x] I have read, understood and followed the project's AI_POLICY.md when creating code, documentation etc. for this pull request.
+
+Submitted by: @jameshilliard
+Date: 2025-12-31
+Related issue(s): #107

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -127,7 +127,13 @@ class LmdbCffiBuildHook(BuildHookInterface):
         Returns True if flatc was successfully built.
         """
         print("\n" + "=" * 70)
-        print("Building FlatBuffers compiler (flatc)")
+        if "ZLMDB_FLATC_EXECUTABLE" in os.environ:
+            flatc_path = Path(os.environ["ZLMDB_FLATC_EXECUTABLE"])
+            print(f"Using prebuilt FlatBuffers compiler (flatc): {flatc_path}")
+            self._flatc_path = flatc_path
+            return True
+        else:
+            print("Building FlatBuffers compiler (flatc)")
         print("=" * 70)
 
         flatbuffers_dir = Path(self.root) / "deps" / "flatbuffers"


### PR DESCRIPTION
Useful for cross compiling as flatc needs to run on the build host rather than the target.

## Description

**Summary**: Build tools need to be compiled for the host, not the target.

**Motivation**: Allows us to use a host built flatc via env override.

**Related Issue(s)**: 
Fixes #107:
```python
======================================================================
Building FlatBuffers compiler (flatc)
======================================================================
  -> Configuring with cmake...
  -> Building flatc...
  -> Built flatc: /home/buildroot/buildroot/output/build/python-zlmdb-25.12.3/src/zlmdb/_flatc/bin/flatc
  -> Verifying ISA level...
     /home/buildroot/buildroot/output/build/python-zlmdb-25.12.3/src/zlmdb/_flatc/bin/flatc: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (GNU/Linux), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 3.7.0, with debug_info, not stripped
  -> Added to wheel: zlmdb/_flatc/bin/flatc

======================================================================
Generating reflection.bfbs
======================================================================
ERROR: flatc failed:
aarch64-binfmt-P: Could not open '/lib/ld-linux-aarch64.so.1': No such file or directory
```


## AI Assistance Disclosure

- [x] This PR was created entirely by a human
- [ ] This PR was created with AI assistance

